### PR TITLE
TF-2638 Update VacationResponse to include null fields (toDate, fromD…

### DIFF
--- a/lib/jmap/mail/vacation/vacation_response.dart
+++ b/lib/jmap/mail/vacation/vacation_response.dart
@@ -18,19 +18,15 @@ class VacationResponse with EquatableMixin {
   @JsonKey(includeIfNull: false)
   final bool? isEnabled;
 
-  @JsonKey(includeIfNull: false)
   final UTCDate? fromDate;
 
-  @JsonKey(includeIfNull: false)
   final UTCDate? toDate;
 
-  @JsonKey(includeIfNull: false)
   final String? subject;
 
   @JsonKey(includeIfNull: false)
   final String? textBody;
 
-  @JsonKey(includeIfNull: false)
   final String? htmlBody;
 
   VacationResponse({

--- a/lib/jmap/mail/vacation/vacation_response.g.dart
+++ b/lib/jmap/mail/vacation/vacation_response.g.dart
@@ -30,12 +30,10 @@ Map<String, dynamic> _$VacationResponseToJson(VacationResponse instance) {
 
   writeNotNull('id', const VacationIdNullableConverter().toJson(instance.id));
   writeNotNull('isEnabled', instance.isEnabled);
-  writeNotNull(
-      'fromDate', const UTCDateNullableConverter().toJson(instance.fromDate));
-  writeNotNull(
-      'toDate', const UTCDateNullableConverter().toJson(instance.toDate));
-  writeNotNull('subject', instance.subject);
+  val['fromDate'] = const UTCDateNullableConverter().toJson(instance.fromDate);
+  val['toDate'] = const UTCDateNullableConverter().toJson(instance.toDate);
+  val['subject'] = instance.subject;
   writeNotNull('textBody', instance.textBody);
-  writeNotNull('htmlBody', instance.htmlBody);
+  val['htmlBody'] = instance.htmlBody;
   return val;
 }

--- a/test/jmap/vacation/set_vacation_method_test.dart
+++ b/test/jmap/vacation/set_vacation_method_test.dart
@@ -75,7 +75,10 @@ void main() {
                   "singleton": {
                     "isEnabled": true,
                     "fromDate": "2022-08-16T15:00:00.000Z",
-                    "textBody": "Hello dab"
+                    "toDate": null,
+                    "subject": null,
+                    "textBody": "Hello dab",
+                    "htmlBody": null
                   }
                 }
               },
@@ -92,7 +95,7 @@ void main() {
         },
         headers: {
           "accept": "application/json;jmapVersion=rfc-8621",
-          "content-length": 677
+          "content-length": 875
         }
       );
 


### PR DESCRIPTION
https://github.com/linagora/tmail-flutter/issues/2638: Update VacationResponse to include null fields (toDate, fromDate, subject, htmlBody)