### PR TITLE
Update properties for `calendar event reply` response

### DIFF
--- a/lib/jmap/mail/calendar/reply/calendar_event_accept_response.dart
+++ b/lib/jmap/mail/calendar/reply/calendar_event_accept_response.dart
@@ -1,3 +1,4 @@
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/method/response/calendar_event_reply_response.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/event_id.dart';
@@ -9,21 +10,21 @@ class CalendarEventAcceptResponse extends CalendarEventReplyResponse {
     super.notFound,
     {
       this.accepted,
-      this.notCreated
+      this.notAccepted
     });
 
   final List<EventId>? accepted;
-  final List<Id>? notCreated;
+  final Map<Id, SetError>? notAccepted;
 
   static CalendarEventAcceptResponse deserialize(Map<String, dynamic> json) {
     return CalendarEventAcceptResponse(
       JsonParsers().parsingAccountId(json),
       JsonParsers().parsingListId(json, 'notFound'),
       accepted: JsonParsers().parsingListEventId(json, 'accepted'),
-      notCreated: JsonParsers().parsingListId(json, 'notCreated'),
+      notAccepted: JsonParsers().parsingMapSetError(json, 'notAccepted'),
     );
   }
 
   @override
-  List<Object?> get props => [...super.props, accepted, notCreated];
+  List<Object?> get props => [...super.props, accepted, notAccepted];
 }

--- a/lib/jmap/mail/calendar/reply/calendar_event_maybe_response.dart
+++ b/lib/jmap/mail/calendar/reply/calendar_event_maybe_response.dart
@@ -1,3 +1,4 @@
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/method/response/calendar_event_reply_response.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/event_id.dart';
@@ -13,14 +14,14 @@ class CalendarEventMaybeResponse extends CalendarEventReplyResponse {
     });
 
   final List<EventId>? maybe;
-  final List<Id>? notMaybe;
+  final Map<Id, SetError>? notMaybe;
 
   static CalendarEventMaybeResponse deserialize(Map<String, dynamic> json) {
     return CalendarEventMaybeResponse(
       JsonParsers().parsingAccountId(json),
       JsonParsers().parsingListId(json, 'notFound'),
       maybe: JsonParsers().parsingListEventId(json, 'maybe'),
-      notMaybe: JsonParsers().parsingListId(json, 'notMaybe'),
+      notMaybe: JsonParsers().parsingMapSetError(json, 'notMaybe'),
     );
   }
 

--- a/lib/jmap/mail/calendar/reply/calendar_event_reject_response.dart
+++ b/lib/jmap/mail/calendar/reply/calendar_event_reject_response.dart
@@ -1,3 +1,4 @@
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/method/response/calendar_event_reply_response.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/event_id.dart';
@@ -13,14 +14,14 @@ class CalendarEventRejectResponse extends CalendarEventReplyResponse {
     });
 
   final List<EventId>? rejected;
-  final List<Id>? notRejected;
+  final Map<Id, SetError>? notRejected;
 
   static CalendarEventRejectResponse deserialize(Map<String, dynamic> json) {
     return CalendarEventRejectResponse(
       JsonParsers().parsingAccountId(json),
       JsonParsers().parsingListId(json, 'notFound'),
       rejected: JsonParsers().parsingListEventId(json, 'rejected'),
-      notRejected: JsonParsers().parsingListId(json, 'notRejected'),
+      notRejected: JsonParsers().parsingMapSetError(json, 'notRejected'),
     );
   }
 

--- a/lib/util/json_parsers.dart
+++ b/lib/util/json_parsers.dart
@@ -2,6 +2,7 @@ import 'package:jmap_dart_client/http/converter/account_id_converter.dart';
 import 'package:jmap_dart_client/http/converter/calendar/event_id_nullable_converter.dart';
 import 'package:jmap_dart_client/http/converter/id_converter.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/event_id.dart';
 
@@ -26,5 +27,10 @@ class JsonParsers {
       .where((element) => element != null)
       .cast<EventId>()
       .toList();
+  }
+
+  Map<Id, SetError>? parsingMapSetError(Map<String, dynamic> json, String key) {
+    return (json[key] as Map<String, dynamic>?)
+      ?.map((key, value) => MapEntry(const IdConverter().fromJson(key), SetError.fromJson(value)));
   }
 }

--- a/test/jmap/mail/calendar/reply/calendar_event_accept_method_test.dart
+++ b/test/jmap/mail/calendar/reply/calendar_event_accept_method_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:jmap_dart_client/http/http_client.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/method/request/calendar_event_reply_method.dart';
 import 'package:jmap_dart_client/jmap/core/method/response/calendar_event_reply_response.dart';
@@ -26,6 +27,7 @@ void main() {
   final notFoundBlobId = Id('ghi789');
   final blobIds = [successBlobId, failureBlobId, notFoundBlobId];
   final methodCallId = MethodCallId('c0');
+  final setErrorFixture = SetError(SetError.invalidPatch, description: '');
 
   Map<String, dynamic> constructData(CalendarEventReplyMethod method) => {
     "using": method.requiredCapabilities
@@ -50,7 +52,9 @@ void main() {
       {
         "accountId": accountId.id.value,
         "accepted": [successBlobId.value],
-        "notCreated": [failureBlobId.value],
+        "notAccepted": {
+          failureBlobId.value: setErrorFixture
+        },
         "notFound": [notFoundBlobId.value],
       },
       methodCallId.value
@@ -82,7 +86,7 @@ void main() {
       
       // assert
       expect((response as CalendarEventAcceptResponse?)?.accepted, equals([EventId(successBlobId.value)]));
-      expect(response?.notCreated, equals([failureBlobId]));
+      expect(response?.notAccepted?.keys.toList(), equals([failureBlobId]));
       expect(response?.notFound, equals([notFoundBlobId]));
     });
   });

--- a/test/jmap/mail/calendar/reply/calendar_event_maybe_method_test.dart
+++ b/test/jmap/mail/calendar/reply/calendar_event_maybe_method_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:jmap_dart_client/http/http_client.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/method/request/calendar_event_reply_method.dart';
 import 'package:jmap_dart_client/jmap/core/method/response/calendar_event_reply_response.dart';
@@ -26,6 +27,7 @@ void main() {
   final notFoundBlobId = Id('ghi789');
   final blobIds = [successBlobId, failureBlobId, notFoundBlobId];
   final methodCallId = MethodCallId('c0');
+  final setErrorFixture = SetError(SetError.invalidPatch, description: '');
 
   Map<String, dynamic> constructData(CalendarEventReplyMethod method) => {
     "using": method.requiredCapabilities
@@ -50,7 +52,9 @@ void main() {
       {
         "accountId": accountId.id.value,
         "maybe": [successBlobId.value],
-        "notMaybe": [failureBlobId.value],
+        "notMaybe": {
+          failureBlobId.value: setErrorFixture
+        },
         "notFound": [notFoundBlobId.value],
       },
       methodCallId.value
@@ -84,7 +88,7 @@ void main() {
       expect(
         (response as CalendarEventMaybeResponse?)?.maybe,
         equals([EventId(successBlobId.value)]));
-      expect(response?.notMaybe, equals([failureBlobId]));
+      expect(response?.notMaybe?.keys, equals([failureBlobId]));
       expect(response?.notFound, equals([notFoundBlobId]));
     });
   });

--- a/test/jmap/mail/calendar/reply/calendar_event_reject_method_test.dart
+++ b/test/jmap/mail/calendar/reply/calendar_event_reject_method_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:jmap_dart_client/http/http_client.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/core/method/request/calendar_event_reply_method.dart';
 import 'package:jmap_dart_client/jmap/core/method/response/calendar_event_reply_response.dart';
@@ -26,6 +27,7 @@ void main() {
   final notFoundBlobId = Id('ghi789');
   final blobIds = [successBlobId, failureBlobId, notFoundBlobId];
   final methodCallId = MethodCallId('c0');
+  final setErrorFixture = SetError(SetError.invalidPatch, description: '');
 
   Map<String, dynamic> constructData(CalendarEventReplyMethod method) => {
     "using": method.requiredCapabilities
@@ -50,7 +52,9 @@ void main() {
       {
         "accountId": accountId.id.value,
         "rejected": [successBlobId.value],
-        "notRejected": [failureBlobId.value],
+        "notRejected": {
+          failureBlobId.value: setErrorFixture
+        },
         "notFound": [notFoundBlobId.value],
       },
       methodCallId.value
@@ -84,7 +88,7 @@ void main() {
       expect(
         (response as CalendarEventRejectResponse?)?.rejected,
         equals([EventId(successBlobId.value)]));
-      expect(response?.notRejected, equals([failureBlobId]));
+      expect(response?.notRejected?.keys.toList(), equals([failureBlobId]));
       expect(response?.notFound, equals([notFoundBlobId]));
     });
   });

--- a/test/util/json_parsers_test.dart
+++ b/test/util/json_parsers_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jmap_dart_client/jmap/account_id.dart';
+import 'package:jmap_dart_client/jmap/core/error/set_error.dart';
 import 'package:jmap_dart_client/jmap/core/id.dart';
 import 'package:jmap_dart_client/jmap/mail/calendar/properties/event_id.dart';
 import 'package:jmap_dart_client/util/json_parsers.dart';
@@ -110,6 +111,59 @@ void main() {
         expect(
           () => jsonParsers.parsingListEventId(json, 'listEventId'),
           throwsA(isA<TypeError>()));
+      });
+    });
+
+    group('parsingMapSetError::test', () {
+      test('SHOULD return map SetError WHEN json contains map SetError object',() {
+        // arrange
+        SetError rawSetError = SetError(
+          SetError.invalidPatch,
+          description: 'invalidPatch');
+
+        final json = <String, dynamic>{
+          'notAccepted': {
+            'eventId': {
+              'type': 'invalidPatch',
+              'description': 'invalidPatch'
+            }
+          }
+        };
+
+        // act
+        final mapSetError = jsonParsers.parsingMapSetError(json, 'notAccepted');
+
+        // assert
+        expect(mapSetError?.keys, equals([Id('eventId')]));
+        expect(mapSetError?.values, equals([rawSetError]));
+      });
+
+      test('SHOULD return null WHEN json does not contains map SetError object',() {
+        // arrange
+        final json = <String, dynamic>{
+          'notAccepted': null
+        };
+
+        // act
+        final mapSetError = jsonParsers.parsingMapSetError(json, 'notAccepted');
+
+        // assert
+        expect(mapSetError, null);
+      });
+
+      test('SHOULD throw TypeError WHEN the value of eventId is not SetError object',() {
+        // arrange
+        final json = <String, dynamic>{
+          'notAccepted': {
+            'eventId': 'dab123'
+          }
+        };
+
+        // assert
+        expect(
+          () => jsonParsers.parsingMapSetError(json, 'notAccepted'),
+          throwsA(isA<TypeError>())
+        );
       });
     });
   });


### PR DESCRIPTION
## Issue

- Correctly update the calendar event reply response according to [BE documents](https://github.com/linagora/tmail-backend/blob/master/docs/modules/ROOT/pages/tmail-backend/jmap-extensions/calendarEventReply.adoc)

## Relate

https://github.com/linagora/tmail-flutter/issues/2907#issuecomment-2148785645