### PR TITLE
Convert `spam` role to `junk`

### DIFF
--- a/lib/jmap/mail/mailbox/mailbox.dart
+++ b/lib/jmap/mail/mailbox/mailbox.dart
@@ -127,7 +127,13 @@ class MailboxName with EquatableMixin {
 class Role with EquatableMixin {
   final String value;
 
-  Role(this.value);
+  // JMAP spec states that mailboxes role must be one of IMAP Mailbox Name Attributes
+  // https://www.iana.org/assignments/imap-mailbox-name-attributes/imap-mailbox-name-attributes.xhtml
+  // According to this link, the attribute name for Junk/Spam folder is `junk`
+  // However, some servers and client use `spam` instead for historical reasons
+  // To allow compatibility, convert `spam` to `junk`.
+  // This should be removed some day, when every server and client has been fixed
+  Role(value) : value = value == "spam" ? "junk" : value;
 
   @override
   List<Object?> get props => [value];

--- a/test/jmap/mailbox/query/query_mailbox_test.dart
+++ b/test/jmap/mailbox/query/query_mailbox_test.dart
@@ -133,26 +133,30 @@ void main() {
 
       final httpClient = HttpClient(dio);
       final processingInvocation = ProcessingInvocation();
-      final jmapRequestBuilder =JmapRequestBuilder(httpClient, processingInvocation);
+      final jmapRequestBuilder =
+          JmapRequestBuilder(httpClient, processingInvocation);
       final accountId = AccountId(Id(
           '0d14dbabe6482aff5cbf922e04cef51a40b4eabccbe12d28fe27c97038752555'));
       final queryMailboxMethod = QueryMailboxMethod(accountId)
         ..addFilters(MailboxFilterCondition(role: Role('Spam')))
         ..addLimit(UnsignedInt(1));
-      final queryMailboxInvocation = jmapRequestBuilder.invocation(queryMailboxMethod, methodCallId: MethodCallId('c2'));
+      final queryMailboxInvocation = jmapRequestBuilder
+          .invocation(queryMailboxMethod, methodCallId: MethodCallId('c2'));
 
       final getMailBoxMethod = GetMailboxMethod(accountId)
         ..addReferenceIds(processingInvocation.createResultReference(
           queryMailboxInvocation.methodCallId,
           ReferencePath('ids/*'),
         ));
-      final getMailboxInvocation = jmapRequestBuilder.invocation(getMailBoxMethod, methodCallId: MethodCallId('c3'));
+      final getMailboxInvocation = jmapRequestBuilder
+          .invocation(getMailBoxMethod, methodCallId: MethodCallId('c3'));
       final result = await (jmapRequestBuilder
             ..usings(getMailBoxMethod.requiredCapabilities))
           .build()
           .execute();
 
-      final resultList = result.parse<GetMailboxResponse>(getMailboxInvocation.methodCallId, GetMailboxResponse.deserialize);
+      final resultList = result.parse<GetMailboxResponse>(
+          getMailboxInvocation.methodCallId, GetMailboxResponse.deserialize);
 
       expect(resultList?.list.first.name?.name, 'Spam');
       expect(resultList?.list.first.role?.value, 'spam');

--- a/test/jmap/mailbox/query/query_mailbox_test.dart
+++ b/test/jmap/mailbox/query/query_mailbox_test.dart
@@ -17,47 +17,104 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/query/query_mailbox_method.da
 
 void main() {
   group('Query mailbox test', () {
-    test('Query Mailbox spam report', () async {
-      final expectedReported = Mailbox(
-        id: MailboxId(Id('9bf84410-32cf-11eb-995c-a3ae66e9f96a')),
-        role: Role('spam'),
-        name: MailboxName('Spam'),
-        sortOrder: SortOrder(sortValue: 70),
-        totalEmails: TotalEmails(UnsignedInt(29)),
-        unreadEmails: UnreadEmails(UnsignedInt(29)),
-        totalThreads: TotalThreads(UnsignedInt(29)),
-        unreadThreads: UnreadThreads(UnsignedInt(29)),
-        myRights: MailboxRights(
-          true,
-          true,
-          true,
-          true,
-          true,
-          true,
-          true,
-          true,
-          true,
-        ),
-        isSubscribed: IsSubscribed(true),
-      );
-      final baseOption = BaseOptions(method: 'POST');
-      final dio = Dio(baseOption)..options.baseUrl = 'http://domain.com/jmap';
-      final dioAdapter = DioAdapter(dio: dio);
-      dioAdapter.onPost(
-          '',
-          (server) => server.reply(200, {
-                "sessionState": "2c9f1b12-b35a-43e6-9af2-0106fb53a943",
-                "methodResponses": [
+    for (final serverRole in ["junk", "spam"]) {
+      for (final clientRole in ["junk", "spam"]) {
+        test(
+            'Query Mailbox server uses ${serverRole} and client uses ${clientRole} role report',
+            () async {
+          final expectedReported = Mailbox(
+            id: MailboxId(Id('9bf84410-32cf-11eb-995c-a3ae66e9f96a')),
+            role: Role(clientRole),
+            name: MailboxName('Spam'),
+            sortOrder: SortOrder(sortValue: 70),
+            totalEmails: TotalEmails(UnsignedInt(29)),
+            unreadEmails: UnreadEmails(UnsignedInt(29)),
+            totalThreads: TotalThreads(UnsignedInt(29)),
+            unreadThreads: UnreadThreads(UnsignedInt(29)),
+            myRights: MailboxRights(
+              true,
+              true,
+              true,
+              true,
+              true,
+              true,
+              true,
+              true,
+              true,
+            ),
+            isSubscribed: IsSubscribed(true),
+          );
+          final baseOption = BaseOptions(method: 'POST');
+          final dio = Dio(baseOption)
+            ..options.baseUrl = 'http://domain.com/jmap';
+          final dioAdapter = DioAdapter(dio: dio);
+          dioAdapter.onPost(
+              '',
+              (server) => server.reply(200, {
+                    "sessionState": "2c9f1b12-b35a-43e6-9af2-0106fb53a943",
+                    "methodResponses": [
+                      [
+                        "Mailbox/query",
+                        {
+                          "accountId":
+                              "0d14dbabe6482aff5cbf922e04cef51a40b4eabccbe12d28fe27c97038752555",
+                          "queryState": "a016715b",
+                          "canCalculateChanges": false,
+                          "ids": ["9bf84410-32cf-11eb-995c-a3ae66e9f96a"],
+                          "position": 0,
+                          "limit": 256
+                        },
+                        "c2"
+                      ],
+                      [
+                        "Mailbox/get",
+                        {
+                          "accountId":
+                              "0d14dbabe6482aff5cbf922e04cef51a40b4eabccbe12d28fe27c97038752555",
+                          "notFound": [],
+                          "state": "210ae7f0-9036-11ed-aaac-2f661c6dc0b9",
+                          "list": [
+                            {
+                              "totalThreads": 29,
+                              "name": "Spam",
+                              "isSubscribed": true,
+                              "role": serverRole,
+                              "totalEmails": 29,
+                              "unreadThreads": 29,
+                              "unreadEmails": 29,
+                              "sortOrder": 70,
+                              "myRights": {
+                                "mayReadItems": true,
+                                "mayAddItems": true,
+                                "mayRemoveItems": true,
+                                "maySetSeen": true,
+                                "maySetKeywords": true,
+                                "mayCreateChild": true,
+                                "mayRename": true,
+                                "mayDelete": true,
+                                "maySubmit": true
+                              },
+                              "id": "9bf84410-32cf-11eb-995c-a3ae66e9f96a"
+                            }
+                          ]
+                        },
+                        "c3"
+                      ]
+                    ]
+                  }),
+              data: {
+                "using": [
+                  "urn:ietf:params:jmap:core",
+                  "urn:ietf:params:jmap:mail"
+                ],
+                "methodCalls": [
                   [
                     "Mailbox/query",
                     {
                       "accountId":
                           "0d14dbabe6482aff5cbf922e04cef51a40b4eabccbe12d28fe27c97038752555",
-                      "queryState": "a016715b",
-                      "canCalculateChanges": false,
-                      "ids": ["9bf84410-32cf-11eb-995c-a3ae66e9f96a"],
-                      "position": 0,
-                      "limit": 256
+                      "filter": {"role": "Spam"},
+                      "limit": 1
                     },
                     "c2"
                   ],
@@ -66,100 +123,54 @@ void main() {
                     {
                       "accountId":
                           "0d14dbabe6482aff5cbf922e04cef51a40b4eabccbe12d28fe27c97038752555",
-                      "notFound": [],
-                      "state": "210ae7f0-9036-11ed-aaac-2f661c6dc0b9",
-                      "list": [
-                        {
-                          "totalThreads": 29,
-                          "name": "Spam",
-                          "isSubscribed": true,
-                          "role": "spam",
-                          "totalEmails": 29,
-                          "unreadThreads": 29,
-                          "unreadEmails": 29,
-                          "sortOrder": 70,
-                          "myRights": {
-                            "mayReadItems": true,
-                            "mayAddItems": true,
-                            "mayRemoveItems": true,
-                            "maySetSeen": true,
-                            "maySetKeywords": true,
-                            "mayCreateChild": true,
-                            "mayRename": true,
-                            "mayDelete": true,
-                            "maySubmit": true
-                          },
-                          "id": "9bf84410-32cf-11eb-995c-a3ae66e9f96a"
-                        }
-                      ]
+                      "#ids": {
+                        "resultOf": "c2",
+                        "name": "Mailbox/query",
+                        "path": "ids/*"
+                      }
                     },
                     "c3"
                   ]
                 ]
-              }),
-          data: {
-            "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
-            "methodCalls": [
-              [
-                "Mailbox/query",
-                {
-                  "accountId":
-                      "0d14dbabe6482aff5cbf922e04cef51a40b4eabccbe12d28fe27c97038752555",
-                  "filter": {"role": "Spam"},
-                  "limit": 1
-                },
-                "c2"
-              ],
-              [
-                "Mailbox/get",
-                {
-                  "accountId":
-                      "0d14dbabe6482aff5cbf922e04cef51a40b4eabccbe12d28fe27c97038752555",
-                  "#ids": {
-                    "resultOf": "c2",
-                    "name": "Mailbox/query",
-                    "path": "ids/*"
-                  }
-                },
-                "c3"
-              ]
-            ]
-          },
-          headers: {
-            "accept": "application/json;jmapVersion=rfc-8621",
-            "content-length": 672
-          });
+              },
+              headers: {
+                "accept": "application/json;jmapVersion=rfc-8621",
+                "content-length": 672
+              });
 
-      final httpClient = HttpClient(dio);
-      final processingInvocation = ProcessingInvocation();
-      final jmapRequestBuilder =
-          JmapRequestBuilder(httpClient, processingInvocation);
-      final accountId = AccountId(Id(
-          '0d14dbabe6482aff5cbf922e04cef51a40b4eabccbe12d28fe27c97038752555'));
-      final queryMailboxMethod = QueryMailboxMethod(accountId)
-        ..addFilters(MailboxFilterCondition(role: Role('Spam')))
-        ..addLimit(UnsignedInt(1));
-      final queryMailboxInvocation = jmapRequestBuilder
-          .invocation(queryMailboxMethod, methodCallId: MethodCallId('c2'));
+          final httpClient = HttpClient(dio);
+          final processingInvocation = ProcessingInvocation();
+          final jmapRequestBuilder =
+              JmapRequestBuilder(httpClient, processingInvocation);
+          final accountId = AccountId(Id(
+              '0d14dbabe6482aff5cbf922e04cef51a40b4eabccbe12d28fe27c97038752555'));
+          final queryMailboxMethod = QueryMailboxMethod(accountId)
+            ..addFilters(MailboxFilterCondition(role: Role('Spam')))
+            ..addLimit(UnsignedInt(1));
+          final queryMailboxInvocation = jmapRequestBuilder
+              .invocation(queryMailboxMethod, methodCallId: MethodCallId('c2'));
 
-      final getMailBoxMethod = GetMailboxMethod(accountId)
-        ..addReferenceIds(processingInvocation.createResultReference(
-          queryMailboxInvocation.methodCallId,
-          ReferencePath('ids/*'),
-        ));
-      final getMailboxInvocation = jmapRequestBuilder
-          .invocation(getMailBoxMethod, methodCallId: MethodCallId('c3'));
-      final result = await (jmapRequestBuilder
-            ..usings(getMailBoxMethod.requiredCapabilities))
-          .build()
-          .execute();
+          final getMailBoxMethod = GetMailboxMethod(accountId)
+            ..addReferenceIds(processingInvocation.createResultReference(
+              queryMailboxInvocation.methodCallId,
+              ReferencePath('ids/*'),
+            ));
+          final getMailboxInvocation = jmapRequestBuilder
+              .invocation(getMailBoxMethod, methodCallId: MethodCallId('c3'));
+          final result = await (jmapRequestBuilder
+                ..usings(getMailBoxMethod.requiredCapabilities))
+              .build()
+              .execute();
 
-      final resultList = result.parse<GetMailboxResponse>(
-          getMailboxInvocation.methodCallId, GetMailboxResponse.deserialize);
+          final resultList = result.parse<GetMailboxResponse>(
+              getMailboxInvocation.methodCallId,
+              GetMailboxResponse.deserialize);
 
-      expect(resultList?.list.first.name?.name, 'Spam');
-      expect(resultList?.list.first.role?.value, 'junk');
-      expect(resultList?.list.first, equals(expectedReported));
-    });
+          expect(resultList?.list.first.name?.name, 'Spam');
+          expect(resultList?.list.first.role?.value, 'junk');
+          expect(resultList?.list.first, equals(expectedReported));
+        });
+      }
+    }
   });
 }

--- a/test/jmap/mailbox/query/query_mailbox_test.dart
+++ b/test/jmap/mailbox/query/query_mailbox_test.dart
@@ -15,7 +15,7 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox_filter_condition.dart
 import 'package:jmap_dart_client/jmap/mail/mailbox/mailbox_rights.dart';
 import 'package:jmap_dart_client/jmap/mail/mailbox/query/query_mailbox_method.dart';
 
-void main(){
+void main() {
   group('Query mailbox test', () {
      final expectedReported = Mailbox(
       id: MailboxId(Id('9bf84410-32cf-11eb-995c-a3ae66e9f96a')),

--- a/test/jmap/mailbox/query/query_mailbox_test.dart
+++ b/test/jmap/mailbox/query/query_mailbox_test.dart
@@ -158,7 +158,7 @@ void main() {
           getMailboxInvocation.methodCallId, GetMailboxResponse.deserialize);
 
       expect(resultList?.list.first.name?.name, 'Spam');
-      expect(resultList?.list.first.role?.value, 'spam');
+      expect(resultList?.list.first.role?.value, 'junk');
       expect(resultList?.list.first, equals(expectedReported));
     });
   });

--- a/test/jmap/mailbox/query/query_mailbox_test.dart
+++ b/test/jmap/mailbox/query/query_mailbox_test.dart
@@ -17,30 +17,29 @@ import 'package:jmap_dart_client/jmap/mail/mailbox/query/query_mailbox_method.da
 
 void main() {
   group('Query mailbox test', () {
-     final expectedReported = Mailbox(
-      id: MailboxId(Id('9bf84410-32cf-11eb-995c-a3ae66e9f96a')),
-      role: Role('spam'),
-      name: MailboxName('Spam'),
-      sortOrder: SortOrder(sortValue: 70),
-      totalEmails: TotalEmails(UnsignedInt(29)),
-      unreadEmails: UnreadEmails(UnsignedInt(29)),
-      totalThreads: TotalThreads(UnsignedInt(29)),
-      unreadThreads: UnreadThreads(UnsignedInt(29)),
-      myRights: MailboxRights(
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-      ),
-     isSubscribed: IsSubscribed(true),
-    );
-
     test('Query Mailbox spam report', () async {
+      final expectedReported = Mailbox(
+        id: MailboxId(Id('9bf84410-32cf-11eb-995c-a3ae66e9f96a')),
+        role: Role('spam'),
+        name: MailboxName('Spam'),
+        sortOrder: SortOrder(sortValue: 70),
+        totalEmails: TotalEmails(UnsignedInt(29)),
+        unreadEmails: UnreadEmails(UnsignedInt(29)),
+        totalThreads: TotalThreads(UnsignedInt(29)),
+        unreadThreads: UnreadThreads(UnsignedInt(29)),
+        myRights: MailboxRights(
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+        ),
+        isSubscribed: IsSubscribed(true),
+      );
       final baseOption = BaseOptions(method: 'POST');
       final dio = Dio(baseOption)..options.baseUrl = 'http://domain.com/jmap';
       final dioAdapter = DioAdapter(dio: dio);


### PR DESCRIPTION
According to the JMAP specification, the role for the Spam/Junk mailbox should be `junk`. However, some servers and client incorrectly use `spam` role (which does not exist in the spec).

This PR modifies the `Role` constructor to treat the `spam` role as `junk`.

Tests have been updated and written, however, it has not yet been tested in TwakeMail (work in progress).