### PR TITLE
Allow `textBody` of `VacationResponse` to be null

### DIFF
--- a/lib/jmap/mail/vacation/vacation_response.dart
+++ b/lib/jmap/mail/vacation/vacation_response.dart
@@ -24,7 +24,6 @@ class VacationResponse with EquatableMixin {
 
   final String? subject;
 
-  @JsonKey(includeIfNull: false)
   final String? textBody;
 
   final String? htmlBody;

--- a/lib/jmap/mail/vacation/vacation_response.g.dart
+++ b/lib/jmap/mail/vacation/vacation_response.g.dart
@@ -33,7 +33,7 @@ Map<String, dynamic> _$VacationResponseToJson(VacationResponse instance) {
   val['fromDate'] = const UTCDateNullableConverter().toJson(instance.fromDate);
   val['toDate'] = const UTCDateNullableConverter().toJson(instance.toDate);
   val['subject'] = instance.subject;
-  writeNotNull('textBody', instance.textBody);
+  val['textBody'] = instance.textBody;
   val['htmlBody'] = instance.htmlBody;
   return val;
 }


### PR DESCRIPTION
## Related issue
- https://github.com/linagora/tmail-flutter/issues/3316